### PR TITLE
Add new regex for matching with all docker tags

### DIFF
--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -294,11 +294,14 @@ func fetchAuthToken(repositoryName string) (string, error) {
 // 	$ curl -H "Authorization: Bearer $token" https://index.docker.io/v2/sourcegraph/server/tags/list
 //
 func (r *repository) fetchAllTags() ([]string, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://index.docker.io/v2/%s/tags/list", r.name), nil)
+	registry, repo, err := parseRegistry(r.name)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s/tags/list", registry, repo), nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+r.authToken)
+	if registry == "https://index.docker.io/v2/" {
+		req.Header.Set("Authorization", "Bearer "+r.authToken)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -17,8 +17,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-var TAG_PATTERN = regexp.MustCompile(`(sourcegraph/.+):(.+)@(sha256:[[:alnum:]]+)`)
-var PATTERN = regexp.MustCompile(`\b(\S+.+):(.+)@(sha256:[[:alnum:]]+)`) // https://regex101.com/r/hP8bK1/38
+var SCRGRAPH_PATTERN = regexp.MustCompile(`(sourcegraph/.+):(.+)@(sha256:[[:alnum:]]+)`)
+var PATTERN = regexp.MustCompile(`\b (\S+.+):(.+)@(sha256:[[:alnum:]]+)`) // https://regex101.com/r/hP8bK1/38
 
 var constraintArgs rawConstraints
 
@@ -71,7 +71,7 @@ Examples:
 	} else if *useGeneric {
 		tagPattern = PATTERN
 	} else {
-		tagPattern = TAG_PATTERN
+		tagPattern = SCRGRAPH_PATTERN
 	}
 
 	o := &options{

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -30,8 +30,7 @@ Usage:
 
 Options:
 	--constraint  (repeatable) enforce a semver constraint for a given docker image
-	--generic     generic matches additional docker image tags
-	--tag-pattern specify a custom regexp to match docker image tags
+	--pattern     specify a custom regexp to match docker image tags
 
 Examples:
 

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -66,7 +66,7 @@ Examples:
 		var err error
 		tagPattern, err = regexp.Compile(*customPattern)
 		if err != nil {
-			log.Fatalf("failed to parse custom regex, err: %s", err)
+			log.Fatalf("failed to parse custom regex: %s", err)
 		}
 	} else if *useGeneric {
 		tagPattern = GENERIC_TAG_PATTERN

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -18,7 +18,7 @@ import (
 )
 
 var TAG_PATTERN = regexp.MustCompile(`(sourcegraph/.+):(.+)@(sha256:[[:alnum:]]+)`)
-var GENERIC_TAG_PATTERN = regexp.MustCompile(` (\S+.+):(.+)@(sha256:[[:alnum:]]+)`) //https://regex101.com/r/hP8bK1/37
+var PATTERN = regexp.MustCompile(`\b(\S+.+):(.+)@(sha256:[[:alnum:]]+)`) // https://regex101.com/r/hP8bK1/38
 
 var constraintArgs rawConstraints
 
@@ -69,7 +69,7 @@ Examples:
 			log.Fatalf("failed to parse custom regex: %s", err)
 		}
 	} else if *useGeneric {
-		tagPattern = GENERIC_TAG_PATTERN
+		tagPattern = PATTERN
 	} else {
 		tagPattern = TAG_PATTERN
 	}

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -48,7 +48,7 @@ Examples:
 	}
 	flag.Var(&constraintArgs, "constraint", "(repeatable) add a semver constraint for a given docker image")
 	useGeneric := flag.Bool("generic", false, "generic matches additional docker image tags")
-	customPattern := flag.String("tag-pattern", "", "specify a custom regexp to match docker image tags")
+	customPattern := flag.String("pattern", "", "specify a custom regexp to match docker images")
 	flag.Parse()
 
 	parsedConstraints, err := constraintArgs.parse()

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -17,8 +17,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var SCRGRAPH_PATTERN = regexp.MustCompile(`(sourcegraph/.+):(.+)@(sha256:[[:alnum:]]+)`)
-var PATTERN = regexp.MustCompile(`\b (\S+.+):(.+)@(sha256:[[:alnum:]]+)`) // https://regex101.com/r/hP8bK1/38
+var PATTERN = regexp.MustCompile(`\b (\S+.+):(.+)@(sha256:[[:alnum:]]+)`) // https://regex101.com/r/hP8bK1/39
 
 var constraintArgs rawConstraints
 
@@ -47,7 +46,6 @@ Examples:
 		os.Exit(2)
 	}
 	flag.Var(&constraintArgs, "constraint", "(repeatable) add a semver constraint for a given docker image")
-	useGeneric := flag.Bool("generic", false, "generic matches additional docker image tags")
 	customPattern := flag.String("pattern", "", "specify a custom regexp to match docker images")
 	flag.Parse()
 
@@ -68,10 +66,8 @@ Examples:
 		if err != nil {
 			log.Fatalf("failed to parse custom regex: %s", err)
 		}
-	} else if *useGeneric {
-		tagPattern = PATTERN
 	} else {
-		tagPattern = SCRGRAPH_PATTERN
+		tagPattern = PATTERN
 	}
 
 	o := &options{

--- a/update-docker-tags_test.go
+++ b/update-docker-tags_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test_genericTag(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+		repo  string
+	}{
+		{
+			"prom",
+			"FROM quay.io/prometheus/busybox-linux-amd64:latest@sha256:0c38f63cbe19e40123668a48c36466ef72b195e723cbfcbe01e9657a5f14cec6",
+			"quay.io/prometheus/busybox-linux-amd64",
+		},
+
+		{
+			"prom2",
+			"FROM prom/prometheus:v2.16.0@sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4 AS upstream",
+			"prom/prometheus",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GENERIC_TAG_PATTERN.FindAllStringSubmatch(tt.image, -1)
+			if got[0][1] != tt.repo {
+				t.Errorf("got = %v, want %v", got, tt.repo)
+			}
+		})
+	}
+}

--- a/update-docker-tags_test.go
+++ b/update-docker-tags_test.go
@@ -21,10 +21,15 @@ func Test_genericTag(t *testing.T) {
 			"FROM prom/prometheus:v2.16.0@sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4 AS upstream",
 			"prom/prometheus",
 		},
+		{
+			"quay",
+			"FROM quay.io/prometheus/busybox-linux-amd64:latest@sha256:0c38f63cbe19e40123668a48c36466ef72b195e723cbfcbe01e9657a5f14cec6",
+			"quay.io/prometheus/busybox-linux-amd64",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GENERIC_TAG_PATTERN.FindAllStringSubmatch(tt.image, -1)
+			got := TAG_PATTERN.FindAllStringSubmatch(tt.image, -1)
 			if got[0][1] != tt.repo {
 				t.Errorf("got = %v, want %v", got, tt.repo)
 			}

--- a/update-docker-tags_test.go
+++ b/update-docker-tags_test.go
@@ -22,14 +22,14 @@ func Test_genericTag(t *testing.T) {
 			"prom/prometheus",
 		},
 		{
-			"quay",
-			"FROM quay.io/prometheus/busybox-linux-amd64:latest@sha256:0c38f63cbe19e40123668a48c36466ef72b195e723cbfcbe01e9657a5f14cec6",
-			"quay.io/prometheus/busybox-linux-amd64",
+			"golang",
+			"FROM golang:1.13-alpine@sha256:ed003971a4809c9ae45afe2d318c24b9e3f6b30864a322877c69a46c504d852c AS builder",
+			"golang:1.13-alpine",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := TAG_PATTERN.FindAllStringSubmatch(tt.image, -1)
+			got := PATTERN.FindAllStringSubmatch(tt.image, -1)
 			if got[0][1] != tt.repo {
 				t.Errorf("got = %v, want %v", got, tt.repo)
 			}


### PR DESCRIPTION
This adds supports for supplying your own regex and includes a builtin regex that should match most docker image tags. 

Still needs some more testing but this is the general approach

PTAL @slimsag 