### PR TITLE
upgrade to semver/v3, add more informative error about constraints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/slimsag/update-docker-tags
 go 1.14
 
 require (
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
+github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 )
 
@@ -131,7 +131,7 @@ func updateDockerTags(o *options, root string) error {
 			} else {
 				latest, err := repository.findLatestSemverTag()
 				if err != nil {
-					replaceErr = errors.Wrapf(err, "when finding the latest semver tag for '%s:%s'", repository.name, originalTag)
+					replaceErr = errors.Wrapf(err, "when finding tag for '%s:%s'", repository.name, originalTag)
 					return groups
 				}
 
@@ -204,6 +204,9 @@ func (r *repository) findLatestSemverTag() (string, error) {
 	}
 
 	if len(versions) == 0 {
+		if r.constraint != nil {
+			return "", fmt.Errorf("no semver tags found for %q matching constraints %q", r.name, r.constraint.String())
+		}
 		return "", fmt.Errorf("no semver tags found for %q", r.name)
 	}
 


### PR DESCRIPTION
Adds better output for cases where image search fails _due to nothing matching provided constraints_. Upgrades to `semver/v3` so that we can get the `Constraints.String()` method to include in this output.

---

Before:

```
2020/11/06 16:07:47 failed to update docker tags for root "base/", err: when replacing image tags in "base/cadvisor/cadvisor.DaemonSet.yaml": when finding the latest semver tag for 'sourcegraph/cadvisor:insiders': no semver tags found for "sourcegraph/cadvisor"
```

This error is a bit scary, since it sounds like a misconfiguration with how our images are published or something wrong with the state of the repository, when really the version I'm attempting to upgrade to simply doesn't exist yet.

After:

```
2020/11/06 16:40:08 failed to update docker tags for root "base/", err: when replacing image tags in "base/cadvisor/cadvisor.DaemonSet.yaml": when finding tag for 'sourcegraph/cadvisor:insiders': no semver tags found for "sourcegraph/cadvisor" matching constraints "3.22.0"
```
